### PR TITLE
Update Evaluate Accuracy function and Manage Mini batches efficiently

### DIFF
--- a/Sentiment_Analysis_with_Apache_MXNet_and_Gluon.ipynb
+++ b/Sentiment_Analysis_with_Apache_MXNet_and_Gluon.ipynb
@@ -349,7 +349,7 @@
    "outputs": [],
    "source": [
     "train_arraydataset = mx.gluon.data.ArrayDataset(trn,y_trn)\n",
-    "train_loader = mx.gluon.data.DataLoader(train_arraydataset,batch_size=batch_size,shuffle=False)"
+    "train_loader = mx.gluon.data.DataLoader(train_arraydataset,batch_size=batch_size,shuffle=False,last_batch='keep')"
    ]
   },
   {
@@ -359,7 +359,7 @@
    "outputs": [],
    "source": [
     "test_arraydataset = mx.gluon.data.ArrayDataset(test,y_test)\n",
-    "test_loader = mx.gluon.data.DataLoader(test_arraydataset,batch_size=batch_size,shuffle=False)"
+    "test_loader = mx.gluon.data.DataLoader(test_arraydataset,batch_size=batch_size,shuffle=False,last_batch='keep')"
    ]
   },
   {

--- a/Sentiment_Analysis_with_Apache_MXNet_and_Gluon.ipynb
+++ b/Sentiment_Analysis_with_Apache_MXNet_and_Gluon.ipynb
@@ -330,6 +330,39 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_classes = 2\n",
+    "num_hidden = 64\n",
+    "learning_rate = .001\n",
+    "epochs = 10\n",
+    "batch_size = 12"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_arraydataset = mx.gluon.data.ArrayDataset(trn,y_trn)\n",
+    "train_loader = mx.gluon.data.DataLoader(train_arraydataset,batch_size=batch_size,shuffle=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_arraydataset = mx.gluon.data.ArrayDataset(test,y_test)\n",
+    "test_loader = mx.gluon.data.DataLoader(test_arraydataset,batch_size=batch_size,shuffle=False)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -342,12 +375,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "num_classes = 2\n",
-    "num_hidden = 64\n",
-    "learning_rate = .001\n",
-    "epochs = 10\n",
-    "batch_size = 12\n",
-    "\n",
     "model = mx.gluon.nn.Sequential()\n",
     "\n",
     "with model.name_scope():    \n",
@@ -369,14 +396,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def evaluate_accuracy(model,x,y,batch_size):\n",
+    "def evaluate_accuracy(model,loader):\n",
     "    correct = 0\n",
     "    total = 0\n",
     "    \n",
-    "    for i in range(x.shape[0] // batch_size):\n",
-    "        data = x[i*batch_size:(i*batch_size + batch_size),]\n",
-    "        target = y[i*batch_size:(i*batch_size + batch_size),]\n",
-    "    \n",
+    "    for _,(data,target) in enumerate(loader):\n",
+    "        \n",
     "        data = data.as_in_context(context)\n",
     "        target = target.as_in_context(context)\n",
     "        \n",
@@ -440,9 +465,7 @@
     "for epoch in range(epochs):\n",
     "    \n",
     "    print('ping')\n",
-    "    for b in range(trn.shape[0] // batch_size):\n",
-    "        data = trn[b*batch_size:(b*batch_size + batch_size),]\n",
-    "        target = y_trn[b*batch_size:(b*batch_size + batch_size),]\n",
+    "    for _,(data,target) in enumerate(train_loader):\n",
     "        \n",
     "        data = data.as_in_context(context)\n",
     "        target = target.as_in_context(context)\n",
@@ -453,8 +476,8 @@
     "            L.backward()\n",
     "        trainer.step(data.shape[0])\n",
     "            \n",
-    "    test_accuracy = evaluate_accuracy(model, trn, y_trn, batch_size)\n",
-    "    train_accuracy = evaluate_accuracy(model, test, y_test, batch_size)\n",
+    "    test_accuracy = evaluate_accuracy(model,train_loader)\n",
+    "    train_accuracy = evaluate_accuracy(model,test_loader)\n",
     "    print(\"Epoch %s. Train_acc %s, Test_acc %s\" %\n",
     "          (epoch, train_accuracy, test_accuracy))"
    ]

--- a/Sentiment_Analysis_with_Apache_MXNet_and_Gluon.ipynb
+++ b/Sentiment_Analysis_with_Apache_MXNet_and_Gluon.ipynb
@@ -370,8 +370,8 @@
    "outputs": [],
    "source": [
     "def evaluate_accuracy(model,x,y,batch_size):\n",
-    "    \n",
-    "    acc = mx.metric.Accuracy()\n",
+    "    correct = 0\n",
+    "    total = 0\n",
     "    \n",
     "    for i in range(x.shape[0] // batch_size):\n",
     "        data = x[i*batch_size:(i*batch_size + batch_size),]\n",
@@ -382,9 +382,10 @@
     "        \n",
     "        output = model(data)\n",
     "        predictions = nd.argmax(output, axis=1)\n",
-    "        acc.update(preds=predictions, labels=target)\n",
+    "        correct+=np.sum(predictions.asnumpy()==target.asnumpy())\n",
+    "        total+=data.shape[0]\n",
     "    \n",
-    "    return acc.get()[1]"
+    "    return float(correct/total)"
    ]
   },
   {
@@ -468,9 +469,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Environment (conda_mxnet_p36)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_mxnet_p36"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -482,7 +483,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*
Issue: #1  acc.update(preds=predictions, labels=target)
                acc.get()[1]

 Managing mini batches efficiently using MXNet Gluon ArrayDataset and DataLoader Modules


*Description of changes:*
1. acc.update updates the accuracy value only for the current batch and acc.get returns the accuracy 
   score for the last batch and not for the entire train/test data.
  Hence I modified function that returns the accuracy score for the entire train/test data.

2. Sequential way of training mini batches will be slower. Also if the batch size if not a divisor of train/test 
   data size then those samples are ignored.
   Hence I used Gluon ArrayDataset loader which combines Ndarrays and forms a dataset object which 
   then be used to create Train/Test Mini batches using DataLoader module. Using last_batch='keep' 
   considers the left over mini batches if batch_size doesn't divide train/test data size

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
